### PR TITLE
bug fix: varargout{2} assignment

### DIFF
--- a/code/notBoxPlot.m
+++ b/code/notBoxPlot.m
@@ -269,7 +269,7 @@ if isvector(y) && isvector(x) && length(x)>1
             thisCI =[];
         end
 
-        h(ii)=notBoxPlot(y(f),u(ii),varargin{:},'manualCI',thisCI); %recursive call
+       [h(ii),s(ii)]=notBoxPlot(y(f),u(ii),varargin{:},'manualCI',thisCI); %recursive call
     end
 
 
@@ -279,9 +279,14 @@ if isvector(y) && isvector(x) && length(x)>1
         set(gca,'XTick',u)
     end
 
-    if nargout==1
+    if nargout>0
         varargout{1}=h;
     end
+    if nargout>1
+        varargout{2}=s;
+    end
+
+
 
     %If we had a table we can label the axes
     if tableOrModelCall


### PR DESCRIPTION
Hi Rob,
I wasn't able to get the stats output argument as described, just an error:
```
One or more output arguments not assigned during call to "varargout".
```

It looks like the recursive call to notBoxPlot didn't assign this second output argument so it couldn't be returned from the main call. 
I just added the second output argument and assignment to varargout{2} and now it seems to work as expected. 

I really appreciate all the tools you've shared. I use shadedErrorBar, sigstar, and now notBoxPlot pretty much daily and I've picked up lots of tricks from how you wrote them. 
Thank you!
Ben